### PR TITLE
Adding spotify account management

### DIFF
--- a/backend/home/routes.py
+++ b/backend/home/routes.py
@@ -44,35 +44,6 @@ def testapi():
         'courses': COURSES
     })
 
-def session_cache_path():
-    return './.spotify_caches/' + session.get('uuid')
-
-@main.route("/link_spotify", methods=['GET', 'POST'])
-def link_spotify():
-    if not session.get('uuid'):
-        session['uuid'] = str(uuid.uuid4())
-    
-    auth_manager = spotipy.oauth2.SpotifyOAuth( client_id=current_app.config['SPOTIFY_CLIENT_ID'], 
-                                                client_secret=current_app.config['SPOTIFY_SECRET_ID'],
-                                                redirect_uri=current_app.config['SPOTIFY_REDIRECT_URI'],
-                                                cache_path=session_cache_path(),
-                                                show_dialog=True,
-                                                scope=SCOPE )
-    
-    if request.args.get('code'):
-        auth_manager.get_access_token(request.args.get("code"))
-        redirect('/link_spotify')
-    
-    if not auth_manager.get_cached_token():
-        auth_url = auth_manager.get_authorize_url()
-        return jsonify({
-            'auth_url': auth_url
-        })
-
-    spotify = spotipy.Spotify(auth_manager=auth_manager)
-    return spotify.current_user()
-
-
 @main.route("/api/post", methods=['POST'])
 @jwt_required
 def post():

--- a/frontend/src/services/auth/auth-module.js
+++ b/frontend/src/services/auth/auth-module.js
@@ -86,6 +86,18 @@ export const auth = {
         }
       );
     },
+    updateSpotifyAccount({ commit }, user) {
+      return AuthService.updateSpotifyAccount(user).then(
+        user => {
+          commit('updateSpotifyAccountSuccess', user);
+          return Promise.resolve(user);
+        },
+        error => {
+          commit('updateSpotifyAccountFailure');
+          return Promise.reject(error);
+        }
+      );
+    },
   },
   mutations: {
     loginSuccess(state, user) {
@@ -131,6 +143,14 @@ export const auth = {
       state.user = user;
     },
     updateAppColorFailure(state, user) {
+      state.status.loggedIn = true;
+      state.user = user;
+    },
+    updateSpotifyAccountSuccess(state, user) {
+      state.status.loggedIn = true;
+      state.user = user;
+    },
+    updateSpotifyAccountFailure(state, user) {
       state.status.loggedIn = true;
       state.user = user;
     }

--- a/frontend/src/services/auth/auth-service.js
+++ b/frontend/src/services/auth/auth-service.js
@@ -8,7 +8,7 @@ const API_URL = 'http://127.0.0.1/api/auth/';
 class AuthService {
   login(form) {
     return axios
-      .post(API_URL + 'login', {
+      .post(AUTH_URL + 'login', {
         email: form.email,
         password: form.password
       })
@@ -31,7 +31,7 @@ class AuthService {
   }
 
   register(form) {
-    return axios.post(API_URL + 'register', {
+    return axios.post(AUTH_URL + 'register', {
       firstname: form.firstname,
       lastname: form.lastname,
       username: form.username,
@@ -42,13 +42,13 @@ class AuthService {
   }
 
   passwordReset(form) {
-    return axios.post(API_URL + 'reset_password', {
+    return axios.post(AUTH_URL + 'reset_password', {
       email: form.email,
     });
   }
 
   passwordResetToken(form) {
-    return axios.post(API_URL + 'reset_password_token', {
+    return axios.post(AUTH_URL + 'reset_password_token', {
       token: form.token,
       password: form.password,
       confirmPassword: form.confirmPassword
@@ -56,7 +56,7 @@ class AuthService {
   }
 
   updateProfile(form) {
-    return axios.post(API_URL + 'update_profile', {
+    return axios.post(AUTH_URL + 'update_profile', {
       firstname: form.firstname,
       lastname: form.lastname,
       username: form.username,
@@ -72,11 +72,24 @@ class AuthService {
   }
 
   updateAppColor(form) {
-    return axios.post(API_URL + 'update_appcolor', {
+    return axios.post(AUTH_URL + 'update_appcolor', {
       appcolor: form.appcolor,
       username: form.username
     }, { headers: authHeader() })
     .then(response => {
+      return response.data;
+    });
+  }
+
+  updateSpotifyAccount(form) {
+    return axios.post(AUTH_URL + 'link_spotify', {
+      spotify_account: form.spotify_account,
+      username: form.username
+    }, { headers: authHeader() } )
+    .then(response => {
+      if(response.data.auth_url) {
+        window.location.href = response.data.auth_url;
+      }
       return response.data;
     });
   }

--- a/frontend/src/views/auth/Profile.vue
+++ b/frontend/src/views/auth/Profile.vue
@@ -37,7 +37,9 @@
     <b-button v-b-modal.edit-profile variant="outline-info" class="mb-2">
       <b-icon icon="pencil-square" aria-hidden="true"></b-icon> Edit Profile
     </b-button>
-
+    <b-button v-b-modal.edit-spotify-account variant="outline-info" class="mb-2">
+      <b-icon icon="pencil-square" aria-hidden="true"></b-icon> Link Spotify
+    </b-button>
     <!-- Modal -->
     <b-modal id="edit-profile" title="Edit Profile" ok-title="Save" @ok="handleOk">
       <b-form @submit.stop.prevent="onSubmit" ref="form" v-if="show">
@@ -119,6 +121,29 @@
 
         </b-form>
     </b-modal>
+
+    <b-modal id="edit-spotify-account" title="Edit Spotify Account" ok-title="Save" @ok="handleOkSpotify">
+      <b-form @submit.stop.prevent="onSubmitSpotify" ref="form" v-if="show">
+        <b-form-group
+          id="input-group-1"
+          label="Spotify Account"
+          label-for="input-1"
+        >
+        <b-form-input
+            id="input-1"
+            name="input-1"
+            v-model="form.spotify_account"
+            type="text"
+            placeholder="Enter spotify account"
+            v-validate="{ required: true, min: 2 }"
+            :state="validateState('input-1')"
+            aria-describedby="input-1-live-feedback"
+            data-vv-as="Spotify Account"
+          ></b-form-input>
+        </b-form-group>
+      </b-form>
+    </b-modal>
+
     <label class="switch">
       <input id="themeToggle" type="checkbox" @click="toggleTheme()">
       <span class="slider round"></span>
@@ -178,7 +203,8 @@ export default {
           firstname: '',
           lastname: '',
           email: '',
-          username: ''
+          username: '', 
+          spotify_account: ''
       },
       show: true,
     };
@@ -188,6 +214,7 @@ export default {
     this.form.lastname = this.$store.state.auth.user.lastname;
     this.form.email = this.$store.state.auth.user.email;
     this.form.username = this.$store.state.auth.user.username;
+    this.form.spotify_account = this.$store.state.auth.user.spotify_account;
   },
   methods: {
     ...mapMutations([
@@ -230,6 +257,26 @@ export default {
         }
       });
     },
+    onSubmitSpotify(){
+      this.loading = false;
+      if (this.form.spotify_account) {
+       this.$store.dispatch('auth/updateSpotifyAccount', this.form).then(
+        () => {
+        // Hide the modal manually
+        this.$nextTick(() => {
+          this.$bvModal.hide('edit-spotify-account')
+        })
+        },
+        error => {
+        this.loading = false;
+        this.successful = false;
+        this.message =
+            (error.response && error.response.data) ||
+            error.message ||
+            error.toString();
+        });
+      }
+    },
     validateState(ref) {
       if (
         this.veeFields[ref] &&
@@ -244,6 +291,12 @@ export default {
         bvModalEvt.preventDefault()
         // Trigger submit handler
         this.onSubmit()
+    },
+    handleOkSpotify(bvModalEvt) {
+      // Prevent modal from closing
+        bvModalEvt.preventDefault()
+        // Trigger submit handler
+        this.onSubmitSpotify()
     }
   }
 };


### PR DESCRIPTION
* This adds a modal to add your spotify account to fyt
* Upon adding the account the endpoint commits the account to the DB and tries to authenticate with spotify
* Upon successful authentication the user is redirected back to the site